### PR TITLE
Fix path to TypeScript declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "unpkg": "dist/umd/index.min.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",


### PR DESCRIPTION
First of all, thank you for providing and maintaining this awesome package.

When i tried to use it in a TypeScript environment, I could not get the types to work, always got this error:
```
Could not find a declaration file for module 'csgo-fade-percentage-calculator'.
```

It looks like this is due to a wrong/outdated `types` path in the `package.json`:
https://github.com/chescos/csgo-fade-percentage-calculator/blob/2656a7d42946f56ec87a22fb42c3b9b51bff2e14/package.json#L10

But this file does not exist:

![image](https://github.com/chescos/csgo-fade-percentage-calculator/assets/29836160/1bd6ac43-fc26-4580-a1af-6188ec89ee42)

This PR fixes the issue by pointing to the declarations file in the `esm` folder.
I tested this locally and can confirm that the types now work properly.
