### PR TITLE
Add Fade Knife Tradeups

### DIFF
--- a/__tests__/modules/FadeCalculator.test.ts
+++ b/__tests__/modules/FadeCalculator.test.ts
@@ -30,7 +30,7 @@ test('Get all fade percentages for weapon', () => {
   const karambitPercentages = FadeCalculator.getFadePercentages('Karambit');
 
   expect(karambitPercentages[3].seed).toBe(3);
-  expect(karambitPercentages[3].ranking).toBe(233);
+  expect(karambitPercentages[3].ranking).toBe(234);
   expect(karambitPercentages[0].percentage).toBe(95.1320370612319);
   expect(karambitPercentages[412].percentage).toBe(100);
   expect(karambitPercentages[763].percentage).toBe(80);
@@ -39,12 +39,12 @@ test('Get all fade percentages for weapon', () => {
   const bayonetPercentages = FadeCalculator.getFadePercentages('Bayonet');
 
   expect(bayonetPercentages[999].seed).toBe(999);
-  expect(bayonetPercentages[999].ranking).toBe(352);
+  expect(bayonetPercentages[999].ranking).toBe(353);
   expect(bayonetPercentages[0].percentage).toBe(84.8679629387681);
   expect(bayonetPercentages[412].percentage).toBe(80);
   expect(bayonetPercentages[763].percentage).toBe(100);
   expect(bayonetPercentages[999].percentage).toBe(86.91688014295212);
-  expect(bayonetPercentages).toHaveLength(1000);
+  expect(bayonetPercentages).toHaveLength(1001);
 
   const mac10Percentages = FadeCalculator.getFadePercentages('MAC-10');
 

--- a/src/modules/FadeCalculator.ts
+++ b/src/modules/FadeCalculator.ts
@@ -40,12 +40,32 @@ class FadeCalculator extends BaseCalculator {
 
   tradeUpWeapons = [
     'AWP',
+    'Bayonet',
+    'Bowie Knife',
+    'Butterfly Knife',
+    'Classic Knife',
+    'Falchion Knife',
+    'Flip Knife',
     'Glock-18',
+    'Gut Knife',
+    'Huntsman Knife',
+    'Karambit',
+    'Kukri Knife',
     'M4A1-S',
+    'M9 Bayonet',
     'MAC-10',
     'MP7',
+    'Navaja Knife',
+    'Nomad Knife',
+    'Paracord Knife',
     'R8 Revolver',
+    'Shadow Daggers',
+    'Skeleton Knife',
+    'Stiletto Knife',
+    'Survival Knife',
+    'Talon Knife',
     'UMP-45',
+    'Ursus Knife',
   ];
 
   configs = {


### PR DESCRIPTION
You can now trade up to Fade knives. This means pattern 1000 is now possible for all knives.